### PR TITLE
Add in Deconstructing CDK Patterns video for EventBridge ETL

### DIFF
--- a/s3-angular-website/README.md
+++ b/s3-angular-website/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the Angular website to Amazon S3 but does no
 ## Deconstructing the S3 Angular Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 
 ## Available Versions

--- a/s3-angular-website/python/README.md
+++ b/s3-angular-website/python/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the Angular website to Amazon S3 but does no
 ## Deconstructing the S3 Angular Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 
 ## How To Use

--- a/s3-angular-website/typescript/README.md
+++ b/s3-angular-website/typescript/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the Angular website to Amazon S3 but does no
 ## Deconstructing the S3 Angular Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 
 ## How To Use

--- a/s3-react-website/README.md
+++ b/s3-react-website/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the React website to Amazon S3 but does not 
 ## Deconstructing the S3 React Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 ## Available Versions
 

--- a/s3-react-website/python/README.md
+++ b/s3-react-website/python/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the React website to Amazon S3 but does not 
 ## Deconstructing the S3 React Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 ## How To Use
 If you have aws configured locally or you are in cloud9 this is as simple as running two commands (assuming your terminal starts at the README.md level):

--- a/s3-react-website/typescript/README.md
+++ b/s3-react-website/typescript/README.md
@@ -10,7 +10,7 @@ This pattern out of the box deploys the React website to Amazon S3 but does not 
 ## Deconstructing the S3 React Deploy Pattern
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tUUNiF0q7rk)
+[![Alt text](https://img.youtube.com/vi/tUUNiF0q7rk/0.jpg)](https://www.youtube.com/watch?v=tUUNiF0q7rk)
 
 ## How To Use
 If you have aws configured locally or you are in cloud9 this is as simple as running two commands (assuming your terminal starts at the README.md level):

--- a/the-destined-lambda/README.md
+++ b/the-destined-lambda/README.md
@@ -56,7 +56,8 @@ Alternatively As illustrated in this implementation, you can use it to strip cus
 
 ## Desconstructing The Destined Lambda
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=DQgq_p6Q03M&feature=youtu.be)
+
+[![Alt text](https://img.youtube.com/vi/DQgq_p6Q03M/0.jpg)](https://www.youtube.com/watch?v=DQgq_p6Q03M)
 
 ## How To Test Pattern
 After you deploy this pattern you will have an API Gateway with one endpoint "SendEvent" that accepts GET requests.

--- a/the-destined-lambda/python/README.md
+++ b/the-destined-lambda/python/README.md
@@ -65,7 +65,7 @@ Alternatively As illustrated in this implementation, you can use it to strip cus
 
 ## Desconstructing The Destined Lambda
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=DQgq_p6Q03M&feature=youtu.be)
+[![Alt text](https://img.youtube.com/vi/DQgq_p6Q03M/0.jpg)](https://www.youtube.com/watch?v=DQgq_p6Q03M)
 
 ## How To Test Pattern
 After you deploy this pattern you will have an API Gateway with one endpoint "SendEvent" that accepts GET requests.

--- a/the-destined-lambda/typescript/README.md
+++ b/the-destined-lambda/typescript/README.md
@@ -56,7 +56,7 @@ Alternatively As illustrated in this implementation, you can use it to strip cus
 
 ## Desconstructing The Destined Lambda
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=DQgq_p6Q03M&feature=youtu.be)
+[![Alt text](https://img.youtube.com/vi/DQgq_p6Q03M/0.jpg)](https://www.youtube.com/watch?v=DQgq_p6Q03M)
 
 ## How To Test Pattern
 After you deploy this pattern you will have an API Gateway with one endpoint "SendEvent" that accepts GET requests.

--- a/the-eventbridge-etl/README.md
+++ b/the-eventbridge-etl/README.md
@@ -28,7 +28,7 @@ If you need to create a process where a user uploads a csv and it gets transform
 
 ## Desconstructing The EventBridge ETL
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+[![Alt text](https://img.youtube.com/vi/8kg5bYsdem4/0.jpg)](https://www.youtube.com/watch?v=8kg5bYsdem4)
 
 ## How to test pattern 
 

--- a/the-eventbridge-etl/README.md
+++ b/the-eventbridge-etl/README.md
@@ -26,6 +26,10 @@ In the current format this is more of a technical demo to show what is possible 
 
 If you need to create a process where a user uploads a csv and it gets transformed and inserted into DynamoDB
 
+## Desconstructing The EventBridge ETL
+If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
+- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+
 ## How to test pattern 
 
 After deployment you will have an s3 bucket where if you go into the aws console for that bucket and upload the file "test_data.csv" found in the data-to-upload folder you will kick everything off.

--- a/the-eventbridge-etl/python/README.md
+++ b/the-eventbridge-etl/python/README.md
@@ -29,7 +29,8 @@ If you need to create a process where a user uploads a csv and it gets transform
 
 ## Desconstructing The EventBridge ETL
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+
+[![Alt text](https://img.youtube.com/vi/8kg5bYsdem4/0.jpg)](https://www.youtube.com/watch?v=8kg5bYsdem4)
 
 ## How to test pattern 
 

--- a/the-eventbridge-etl/python/README.md
+++ b/the-eventbridge-etl/python/README.md
@@ -27,6 +27,10 @@ In the current format this is more of a technical demo to show what is possible 
 
 If you need to create a process where a user uploads a csv and it gets transformed and inserted into DynamoDB
 
+## Desconstructing The EventBridge ETL
+If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
+- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+
 ## How to test pattern 
 
 After deployment you will have an s3 bucket where if you go into the aws console for that bucket and upload the file [test_data.csv](data-to-upload/test_data.csv) found in the data-to-upload folder you will kick everything off.

--- a/the-eventbridge-etl/python/README.md
+++ b/the-eventbridge-etl/python/README.md
@@ -29,7 +29,6 @@ If you need to create a process where a user uploads a csv and it gets transform
 
 ## Desconstructing The EventBridge ETL
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-
 [![Alt text](https://img.youtube.com/vi/8kg5bYsdem4/0.jpg)](https://www.youtube.com/watch?v=8kg5bYsdem4)
 
 ## How to test pattern 

--- a/the-eventbridge-etl/typescript/README.md
+++ b/the-eventbridge-etl/typescript/README.md
@@ -29,7 +29,7 @@ If you need to create a process where a user uploads a csv and it gets transform
 
 ## Desconstructing The EventBridge ETL
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
-- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+[![Alt text](https://img.youtube.com/vi/8kg5bYsdem4/0.jpg)](https://www.youtube.com/watch?v=8kg5bYsdem4)
 
 ## How to test pattern 
 

--- a/the-eventbridge-etl/typescript/README.md
+++ b/the-eventbridge-etl/typescript/README.md
@@ -27,6 +27,10 @@ In the current format this is more of a technical demo to show what is possible 
 
 If you need to create a process where a user uploads a csv and it gets transformed and inserted into DynamoDB
 
+## Desconstructing The EventBridge ETL
+If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
+- [Youtube](https://www.youtube.com/watch?v=8kg5bYsdem4)
+
 ## How to test pattern 
 
 After deployment you will have an s3 bucket where if you go into the aws console for that bucket and upload the file [test_data.csv](data-to-upload/test_data.csv) found in the data-to-upload folder you will kick everything off.

--- a/the-lambda-trilogy/README.md
+++ b/the-lambda-trilogy/README.md
@@ -65,7 +65,7 @@ This is using the lambda runtime container like a docker container. You use a we
 ## Deconstructing The Lambda Trilogy
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tHD3i06Z6gU&feature=youtu.be)
+[![Alt text](https://img.youtube.com/vi/tHD3i06Z6gU/0.jpg)](https://www.youtube.com/watch?v=tHD3i06Z6gU)
 
 ## What's In This CDK Pattern?
 I have bundled fully TypeScript and fully Python versions (including the lambdas) for all 3 lambda states inside this pattern because most of the logic takes place outside the AWS CDK infrastructure code.

--- a/the-lambda-trilogy/python/README.md
+++ b/the-lambda-trilogy/python/README.md
@@ -65,7 +65,7 @@ This is using the lambda runtime container like a docker container. You use a we
 ## Deconstructing The Lambda Trilogy
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tHD3i06Z6gU&feature=youtu.be)
+[![Alt text](https://img.youtube.com/vi/tHD3i06Z6gU/0.jpg)](https://www.youtube.com/watch?v=tHD3i06Z6gU)
 
 ## What's In This CDK Pattern?
 I have bundled fully TypeScript and fully Python versions (including the lambdas) for all 3 lambda states inside this pattern because most of the logic takes place outside the AWS CDK infrastructure code.

--- a/the-lambda-trilogy/typescript/README.md
+++ b/the-lambda-trilogy/typescript/README.md
@@ -65,7 +65,7 @@ This is using the lambda runtime container like a docker container. You use a we
 ## Deconstructing The Lambda Trilogy
 If you want a walkthrough of the theory, the code and finally a demo of the deployed implementation check out:
 
-- [YouTube](https://www.youtube.com/watch?v=tHD3i06Z6gU&feature=youtu.be)
+[![Alt text](https://img.youtube.com/vi/tHD3i06Z6gU/0.jpg)](https://www.youtube.com/watch?v=tHD3i06Z6gU)
 
 ## What's In This CDK Pattern?
 I have bundled fully TypeScript and fully Python versions (including the lambdas) for all 3 lambda states inside this pattern because most of the logic takes place outside the AWS CDK infrastructure code.


### PR DESCRIPTION
I also was able to tidy up the markdown for :
- The destined lambda
- The lambda trilogy
- S3 React / Angular deploy

so that they show the video thumbnail when viewing the README