### PR TITLE
Adds correct value in lambda response for python project

### DIFF
--- a/the-simple-graphql-service/python/lambda_fns/loyalty.js
+++ b/the-simple-graphql-service/python/lambda_fns/loyalty.js
@@ -13,7 +13,7 @@ const sendRes = (status, body) => {
         headers: {
             "Content-Type": "application/json"
         },
-        level: loyaltylevel
+        level: body
     };
     return response;
 };


### PR DESCRIPTION
`sendRes` was incorrectly returning `loyaltylevel` instead of `body`. `loyaltylevel` was not available in this scope and thus would error out.