### PR TITLE
Modified files to update code to CDK V2 from CDK V1

### DIFF
--- a/the-lambda-power-tuner/python/app.py
+++ b/the-lambda-power-tuner/python/app.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-from aws_cdk import core
+from aws_cdk import App
 
 from the_lambda_power_tuner.the_lambda_power_tuner_stack import TheLambdaPowerTunerStack
 
 
-app = core.App()
+app = App()
 TheLambdaPowerTunerStack(app, "the-lambda-power-tuner")
 
 app.synth()

--- a/the-lambda-power-tuner/python/cdk.json
+++ b/the-lambda-power-tuner/python/cdk.json
@@ -1,7 +1,6 @@
 {
   "app": "python3 app.py",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true"
   }
 }

--- a/the-lambda-power-tuner/python/the_lambda_power_tuner/the_lambda_power_tuner_stack.py
+++ b/the-lambda-power-tuner/python/the_lambda_power_tuner/the_lambda_power_tuner_stack.py
@@ -1,13 +1,14 @@
 from aws_cdk import (
+    CfnOutput,
     aws_lambda as _lambda,
     aws_sam as sam,
-    core
+    Stack
 )
+from constructs import Construct
 
+class TheLambdaPowerTunerStack(Stack):
 
-class TheLambdaPowerTunerStack(core.Stack):
-
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         power_values = '128,256,512,1024,1536,3008'
@@ -24,7 +25,7 @@ class TheLambdaPowerTunerStack(core.Stack):
         # lambda_resource = example_lambda.function_arn
 
         # Output the Lambda function ARN in the deploy logs to ease testing
-        core.CfnOutput(self, 'LambdaARN', value=example_lambda.function_arn)
+        CfnOutput(self, 'LambdaARN', value=example_lambda.function_arn)
 
         # Deploy the aws-lambda-powertuning application from the Serverless Application Repository
         # https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:451282441545:applications~aws-lambda-power-tuning
@@ -35,5 +36,3 @@ class TheLambdaPowerTunerStack(core.Stack):
             "lambdaResource": lambda_resource,
             "PowerValues": power_values
         })
-
-


### PR DESCRIPTION
Current codebase for lambda-power-tuning (python) is supporting CDK v1. My customer recently tried to use the power tuning tool but failed as post CDK V2 mostly all development teams have updated to CDK V2.
I have updated the python project to CDV2, so that all the customers who will be using this in future do not experience any issue.
I have test the build it is successful (image attached)
![Build Success](https://user-images.githubusercontent.com/10227573/202614027-866a88fc-48df-43d9-a0ac-92b2526c373a.png)
